### PR TITLE
Update svelte-drag

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "smui-theme": "^5.0.0-beta.8",
     "svelte": "^3.42.6",
     "svelte-check": "^2.2.6",
-    "svelte-drag": "^2.0.1",
+    "svelte-drag": "^2.2.1",
     "svelte-preprocess": "^4.9.4",
     "tslib": "^2.3.1",
     "typescript": "^4.4.3",


### PR DESCRIPTION
There's a bug in 2.0.1, which I fixed in 2.0.4. 